### PR TITLE
finish background removal plugin

### DIFF
--- a/BackgroundRemoval.ui
+++ b/BackgroundRemoval.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>436</width>
-    <height>847</height>
+    <width>435</width>
+    <height>863</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -543,7 +543,7 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="0">
+         <item row="4" column="0">
           <widget class="QLabel" name="label_14">
            <property name="text">
             <string>Evaluation Cap :</string>
@@ -554,7 +554,7 @@
           </widget>
          </item>
          <item row="3" column="1">
-          <widget class="QLabel" name="runEvalCapVal">
+          <widget class="QLabel" name="runRemoveVal">
            <property name="font">
             <font>
              <italic>false</italic>
@@ -564,6 +564,23 @@
            <property name="autoFillBackground">
             <bool>false</bool>
            </property>
+           <property name="styleSheet">
+            <string notr="true">color: rgb(13, 114, 255);</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_9">
+           <property name="text">
+            <string>Remove Value</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QLabel" name="runEvalCapVal">
            <property name="styleSheet">
             <string notr="true">color: rgb(13, 114, 255);</string>
            </property>
@@ -584,7 +601,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>436</width>
+     <width>435</width>
      <height>22</height>
     </rect>
    </property>

--- a/BackgroundRemoval.ui
+++ b/BackgroundRemoval.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>435</width>
-    <height>838</height>
+    <height>837</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -57,6 +57,19 @@
        </item>
        <item>
         <widget class="QListWidget" name="loadingPointsList"/>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="loadingReuseButton">
+         <property name="layoutDirection">
+          <enum>Qt::LeftToRight</enum>
+         </property>
+         <property name="text">
+          <string>Reuse Figure(s)</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -152,17 +165,31 @@
           </layout>
          </item>
          <item>
-          <widget class="QPushButton" name="rparamsTestButton">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Test</string>
-           </property>
-          </widget>
+          <layout class="QHBoxLayout" name="horizontalLayout_8">
+           <item>
+            <widget class="QPushButton" name="rparamsTestButton">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Test</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="rparamsReuseButton">
+             <property name="text">
+              <string>Reuse Figure(s)</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
         </layout>
        </item>

--- a/BackgroundRemoval.ui
+++ b/BackgroundRemoval.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>435</width>
-    <height>837</height>
+    <width>436</width>
+    <height>847</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -382,7 +382,24 @@
           </layout>
          </item>
          <item>
-          <widget class="QTableWidget" name="eparamsTable"/>
+          <widget class="QTableWidget" name="eparamsTable">
+           <property name="columnCount">
+            <number>2</number>
+           </property>
+           <attribute name="verticalHeaderVisible">
+            <bool>false</bool>
+           </attribute>
+           <column>
+            <property name="text">
+             <string>rm val</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>eval cap</string>
+            </property>
+           </column>
+          </widget>
          </item>
         </layout>
        </item>
@@ -567,7 +584,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>435</width>
+     <width>436</width>
      <height>22</height>
     </rect>
    </property>

--- a/BackgroundRemoval.ui
+++ b/BackgroundRemoval.ui
@@ -376,7 +376,7 @@
           </layout>
          </item>
          <item>
-          <widget class="QTableView" name="eparamsTable"/>
+          <widget class="QTableWidget" name="eparamsTable"/>
          </item>
         </layout>
        </item>

--- a/BackgroundRemoval.ui
+++ b/BackgroundRemoval.ui
@@ -155,7 +155,7 @@
               <enum>QAbstractSpinBox::NoButtons</enum>
              </property>
              <property name="decimals">
-              <number>0</number>
+              <number>1</number>
              </property>
              <property name="value">
               <double>1.000000000000000</double>
@@ -329,7 +329,10 @@
                 <enum>QAbstractSpinBox::NoButtons</enum>
                </property>
                <property name="decimals">
-                <number>1</number>
+                <number>0</number>
+               </property>
+               <property name="value">
+                <double>2.000000000000000</double>
                </property>
               </widget>
              </item>
@@ -353,7 +356,10 @@
                 <enum>QAbstractSpinBox::NoButtons</enum>
                </property>
                <property name="decimals">
-                <number>1</number>
+                <number>0</number>
+               </property>
+               <property name="value">
+                <double>10.000000000000000</double>
                </property>
               </widget>
              </item>

--- a/amp.py
+++ b/amp.py
@@ -8,6 +8,18 @@ from importlib import import_module
 
 
 def load_plugin(ui_file: str, main_viewer: QtWidgets.QMainWindow) -> QtWidgets.QMainWindow:
+    """Load plugin from file and return an instance
+
+    Args:
+        ui_file (str):
+            File path to plugin.  This must be a .py file.
+        main_viewer (QtWidgets.QMainWindow):
+            Main viewer instance.  Plugins need to contain a reference to the main viewer.
+
+    Returns:
+        QtWidgets.QMainWindow:
+            Plugin defined within ui_file
+    """
     imp_name = os.path.basename(ui_file).split('.')[0]
     plugin = import_module(imp_name)
     builder = getattr(plugin, 'build_as_plugin')

--- a/amp.py
+++ b/amp.py
@@ -1,11 +1,13 @@
 import os
 
+from PyQt5 import QtWidgets
+
 from importlib import import_module
 
 # tools for loading amp plugins
 
 
-def load_plugin(ui_file, main_viewer):
+def load_plugin(ui_file: str, main_viewer: QtWidgets.QMainWindow) -> QtWidgets.QMainWindow:
     imp_name = os.path.basename(ui_file).split('.')[0]
     plugin = import_module(imp_name)
     builder = getattr(plugin, 'build_as_plugin')

--- a/amp.py
+++ b/amp.py
@@ -9,7 +9,7 @@ from importlib import import_module
 def load_plugin(ui_file, main_viewer):
     imp_name = os.path.basename(ui_file).split('.')[0]
     plugin = import_module(imp_name)
-    builder = getattr(plugin, 'buildAsPlugin')
+    builder = getattr(plugin, 'build_as_plugin')
     return builder(main_viewer)
 
 

--- a/amp.py
+++ b/amp.py
@@ -3,7 +3,6 @@ import os
 from importlib import import_module
 
 # tools for loading amp plugins
-# TODO: Reimplement to build plugin from a *.py file
 
 
 def load_plugin(ui_file, main_viewer):

--- a/background_removal.py
+++ b/background_removal.py
@@ -1,3 +1,5 @@
+# start custom imports
+# end custom imports
 from PyQt5 import QtWidgets, QtCore, uic
 
 from mplwidget import ImagePlot
@@ -18,6 +20,55 @@ import numbers
 class BackgroundRemoval(QtWidgets.QMainWindow):
 
     def __init__(self, main_viewer: MainViewer):
+        # start typedef
+        self.statusbar: QtWidgets.QStatusBar
+        self.menubar: QtWidgets.QMenuBar
+        self.runEvalCapVal: QtWidgets.QLabel
+        self.label_14: QtWidgets.QLabel
+        self.runBackCapVal: QtWidgets.QLabel
+        self.label_12: QtWidgets.QLabel
+        self.runThreshVal: QtWidgets.QLabel
+        self.label_10: QtWidgets.QLabel
+        self.runGausRadiusVal: QtWidgets.QLabel
+        self.label_8: QtWidgets.QLabel
+        self.runBackgroundButton: QtWidgets.QPushButton
+        self.runLoadButton: QtWidgets.QPushButton
+        self.runGroup: QtWidgets.QGroupBox
+        self.eparamsTable: QtWidgets.QTableView
+        self.eparamsEvalAllButton: QtWidgets.QPushButton
+        self.eparamsEvalButton: QtWidgets.QPushButton
+        self.eparamsEvalCapBox: QtWidgets.QDoubleSpinBox
+        self.label_7: QtWidgets.QLabel
+        self.eparamsRemoveBox: QtWidgets.QDoubleSpinBox
+        self.label_6: QtWidgets.QLabel
+        self.eparamsPointSelect: QtWidgets.QComboBox
+        self.label_5: QtWidgets.QLabel
+        self.label_4: QtWidgets.QLabel
+        self.eparamsChannelSelect: QtWidgets.QComboBox
+        self.eparamsReloadButton: QtWidgets.QPushButton
+        self.eparamsDeleteButton: QtWidgets.QPushButton
+        self.eparamsGroup: QtWidgets.QGroupBox
+        self.rparamsReloadButton: QtWidgets.QPushButton
+        self.rparamsDeleteButton: QtWidgets.QPushButton
+        self.rparamsTable: QtWidgets.QTableWidget
+        self.rparamsReuseButton: QtWidgets.QRadioButton
+        self.rparamsTestButton: QtWidgets.QPushButton
+        self.rparamsGausRadiusBox: QtWidgets.QDoubleSpinBox
+        self.label_2: QtWidgets.QLabel
+        self.label_3: QtWidgets.QLabel
+        self.rparamsBackCapBox: QtWidgets.QDoubleSpinBox
+        self.label: QtWidgets.QLabel
+        self.rparamsThreshBox: QtWidgets.QDoubleSpinBox
+        self.rparamsGroup: QtWidgets.QGroupBox
+        self.loadingReuseButton: QtWidgets.QRadioButton
+        self.loadingPointsList: QtWidgets.QListWidget
+        self.loadingChannelSelect: QtWidgets.QComboBox
+        self.loadingRemoveButton: QtWidgets.QPushButton
+        self.loadingAddButton: QtWidgets.QPushButton
+        self.loadingGroup: QtWidgets.QGroupBox
+        self.centralwidget: QtWidgets.QWidget
+        # end typedef
+
         super().__init__()
 
         # set reference to main window
@@ -37,8 +88,6 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
         self.executer = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
         # connect UI callbacks
-        # TODO: find a good way to automatically determine the types for these
-        #       from .ui files
         self.loadingAddButton.clicked.connect(self.on_add_point)
         self.loadingPointsList.currentItemChanged.connect(self.on_point_change)
         self.loadingChannelSelect.currentTextChanged.connect(self.on_channel_change)
@@ -546,7 +595,8 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
 
             # generate plot object for mask and create figure
             mask_name = \
-                self._gen_mask_fig_name(current_point, current_channel, [radius, threshold, backcap])
+                self._gen_mask_fig_name(current_point, current_channel,
+                                        [radius, threshold, backcap])
 
             im_plot = ImagePlot(background_mask)
             if self.br_reuse_id is not None and self.rparamsReuseButton.isChecked():

--- a/background_removal.py
+++ b/background_removal.py
@@ -24,6 +24,8 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
         self.statusbar: QtWidgets.QStatusBar
         self.menubar: QtWidgets.QMenuBar
         self.runEvalCapVal: QtWidgets.QLabel
+        self.label_9: QtWidgets.QLabel
+        self.runRemoveVal: QtWidgets.QLabel
         self.label_14: QtWidgets.QLabel
         self.runBackCapVal: QtWidgets.QLabel
         self.label_12: QtWidgets.QLabel
@@ -113,7 +115,10 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
         # self.eparamsTable.cellClicked.connect()
         # self.eparamsTable.currentCellChanged.connect()
 
-        # self.setWindowTitle("Background Removal")
+        self.runLoadButton.clicked.connect(self.on_load_params)
+        self.runBackgroundButton.clicked.connect(self.on_run_background)
+
+        self.setWindowTitle("Background Removal")
 
     # closeEvent is reserved by pyqt so it can't follow style guide :/
     def closeEvent(self, event: QtCore.QEvent) -> None:
@@ -819,6 +824,34 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
             self.eparamsEvalCapBox.setValue(
                 float(self.eparamsTable.item(current_row, 1).text())
             )
+
+    def on_load_params(self) -> None:
+        """
+        """
+
+        self.runGausRadiusVal.setText(self.rparamsGausRadiusBox.text())
+        self.runThreshVal.setText(self.rparamsThreshBox.text())
+        self.runBackCapVal.setText(self.rparamsBackCapBox.text())
+        self.runRemoveVal.setText(self.eparamsRemoveBox.text())
+        self.runEvalCapVal.setText(self.eparamsEvalCapBox.text())
+
+        self.runBackgroundButton.setEnabled(True)
+
+    def on_run_background(self) -> None:
+        """
+        """
+
+        # loop over all loaded points
+
+        # create directory structure as needed
+
+        # compute background mask
+
+        # loop over channels and remove bg
+
+        # write log file out
+
+        return
 
 
 # function for amp plugin building

--- a/background_removal.py
+++ b/background_removal.py
@@ -223,22 +223,29 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
         """
 
         if self.loadingPointsList.currentItem():
+            # get current point key value
             current_point = self.loadingPointsList.currentItem().text()
 
+            # remove all of current point's figure ids
             if self.main_viewer.figures.remove_figures(
                 self.points[current_point].figure_ids
             ):
                 print('Figures successfully removed')
             else:
+                # this indicates a problem w/ either figure manager
+                # or untracked figure-point ownerships/associations
                 print('Some figures could not be located for removal')
 
+            # clear figure id's if they're associated with the removed point
             if self.preview_id in self.points[current_point].figure_ids:
                 self.preview_id = None
             if self.br_reuse_id in self.points[current_point].figure_ids:
                 self.br_reuse_id = None
 
+            # directly remove the point from the dictionary
             del self.points[current_point]
 
+            # remove point from point list
             self.loadingPointsList.takeItem(
                 self.loadingPointsList.currentRow()
             )
@@ -252,7 +259,7 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
         Generates binaraized mask used for background removal
 
         Args:
-            background_image (ndarray): background channel to create mask with
+            background_image (ndarray): background channel to create mask with (const)
             radius (float): radius of gaussian blur
             theshold (float): binarization threshold post-bluring
             backcap (int): maximum pixel value pre-bluring
@@ -262,6 +269,7 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
 
         """
 
+        # generate new array
         background_mask = np.zeros_like(background_image)
 
         # apply cap

--- a/background_removal.py
+++ b/background_removal.py
@@ -105,7 +105,7 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
         # removal evaluation UI callbacks
         self.eparamsPointSelect.currentTextChanged.connect(self.on_eparams_point_change)
         self.eparamsEvalButton.clicked.connect(self.on_eval_click)
-        # self.eparamsEvalAllButton.clicked.connect()
+        self.eparamsEvalAllButton.clicked.connect(self.on_eval_all_click)
         # self.eparamsDeleteButton.clicked.connect()
         # self.eparamsReloadButton.clicked.connect()
 
@@ -731,6 +731,50 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
         # show after image as different plot
         processed_channel[processed_channel > eval_cap] = eval_cap
         self._add_update_figure(None, eval_point, ImagePlot(processed_channel), after_name)
+
+    def on_eval_all_click(self) -> None:
+        """Callback function for evaluate all button.  Runs evaluation over all loaded points
+        """
+
+        # get fixed chanels
+        eval_channel = self.eparamsChannelSelect.currentText()
+        bg_channel = self.loadingChannelSelect.currentText()
+
+        # get relevant parameters
+        radius = self.rparamsGausRadiusBox.value()
+        threshold = self.rparamsThreshBox.value()
+        backcap = self.rparamsBackCapBox.value()
+        remove_value = self.eparamsRemoveBox.value()
+
+        eval_cap = self.eparamsEvalCapBox.value()
+
+        for index in range(self.eparamsPointSelect.count()):
+            eval_point = self.eparamsPointSelect.itemText(index)
+
+            before_name, after_name = \
+                self._gen_eval_fig_names(eval_point, eval_channel,
+                                         [radius, threshold, backcap, remove_value])
+
+            channel_data = self.points[eval_point].get_channel_data([eval_channel, bg_channel])
+
+            unprocessed_channel = np.copy(channel_data[eval_channel].astype('int'))
+            unprocessed_channel[unprocessed_channel > eval_cap] = eval_cap
+
+            # get preview image for before and plot
+            self._add_update_figure(None, eval_point, ImagePlot(unprocessed_channel), before_name)
+
+            processed_channel = self._evaluate_channel(
+                channel_data[bg_channel],
+                channel_data[eval_channel],
+                radius,
+                threshold,
+                backcap,
+                remove_value
+            )
+
+            # show after image as different plot
+            processed_channel[processed_channel > eval_cap] = eval_cap
+            self._add_update_figure(None, eval_point, ImagePlot(processed_channel), after_name)
 
 
 # function for amp plugin building

--- a/background_removal.py
+++ b/background_removal.py
@@ -1,11 +1,8 @@
-import sys
-
 from PyQt5 import QtWidgets, QtCore, uic
 
 from mplwidget import ImagePlot
 from point import Point
 
-from PIL import Image
 import numpy as np
 from scipy.ndimage import gaussian_filter
 
@@ -35,14 +32,15 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
         self.executer = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
         # connect UI callbacks
-        self.loadingAddButton.clicked.connect(self.onAddPoint)
-        self.loadingPointsList.currentItemChanged.connect(self.onPointChange)
-        self.loadingChannelSelect.currentTextChanged.connect(self.onChannelChange)
-        self.loadingRemoveButton.clicked.connect(self.onRemovePoint)
-        self.rparamsTestButton.clicked.connect(self.testBRParams)
+        self.loadingAddButton.clicked.connect(self.on_add_point)
+        self.loadingPointsList.currentItemChanged.connect(self.on_point_change)
+        self.loadingChannelSelect.currentTextChanged.connect(self.on_channel_change)
+        self.loadingRemoveButton.clicked.connect(self.on_remove_point)
+        self.rparamsTestButton.clicked.connect(self.test_br_params)
 
         self.setWindowTitle("Background Removal")
 
+    # closeEvent is reserved by pyqt so it can't follow style guide :/
     def closeEvent(self, event):
         """ Callback for exiting/closing plugin window
 
@@ -53,7 +51,7 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
 
         """
         while len(self.points) > 0:
-            self.onRemovePoint()
+            self.on_remove_point()
 
         event.accept()
 
@@ -70,7 +68,7 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
         """
         return self.points[point_name].get_channel_data(chans=[channel_name])[channel_name]
 
-    def onAddPoint(self):
+    def on_add_point(self):
         """ Callback for Add Point button
 
         Checks for point existence and adds it to loadingPointsList
@@ -97,7 +95,7 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
                 self.points[point_path] = Point(point_path, tifs)
                 self.loadingPointsList.addItem(point_path)
 
-    def onPointChange(self, current, previous):
+    def on_point_change(self, current, previous):
         """ Callback for changing point selection in point list
 
         Reset's channel selection box options, updates plots, and refills
@@ -168,9 +166,9 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
                                       2,
                                       QtWidgets.QTableWidgetItem(f'{br_params[2]}'))
 
-        self.main_viewer.refreshPlots()
+        self.main_viewer.refresh_plots()
 
-    def onChannelChange(self, current_text):
+    def on_channel_change(self, current_text):
         """ Callback for background channel reselection
 
         Refreshes plots w/ new background channel
@@ -200,7 +198,7 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
                 and self.points[current_point].get_param('BR_params') is not None
             ):
                 br_params = self.points[current_point].get_param('BR_params')[0]
-                channel_mask = self._generateMask(
+                channel_mask = self._generate_mask(
                     channel_data,
                     *br_params
                 )
@@ -213,9 +211,9 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
                     )
 
             # refresh plots
-            self.main_viewer.refreshPlots()
+            self.main_viewer.refresh_plots()
 
-    def onRemovePoint(self):
+    def on_remove_point(self):
         """ Callback for Remove Point button
 
         Removes point from list and clears its associated figures
@@ -253,7 +251,7 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
         else:
             print('No points are currently loaded...')
 
-    def _generateMask(self, background_image, radius, threshold, backcap):
+    def _generate_mask(self, background_image, radius, threshold, backcap):
         """ Mask generation algorithm
 
         Generates binaraized mask used for background removal
@@ -289,7 +287,7 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
 
         return background_mask
 
-    def testBRParams(self):
+    def test_br_params(self):
         """ Callback for background removal 'test' button
 
         Generates background mask with current parameters, plots it,
@@ -312,7 +310,7 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
         backcap = self.rparamsBackCapBox.value()
 
         # generate mask
-        background_mask = self._generateMask(
+        background_mask = self._generate_mask(
             background_image,
             radius,
             threshold,
@@ -350,11 +348,11 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
                                   2,
                                   QtWidgets.QTableWidgetItem(f'{backcap}'))
 
-        self.main_viewer.refreshPlots()
+        self.main_viewer.refresh_plots()
 
 
 # function for amp plugin building
-def buildAsPlugin(main_viewer):
+def build_as_plugin(main_viewer):
     """ Returns an instance of BackgroundRemoval
 
     This function is common to all plugins; it allows the plugin loader

--- a/background_removal.py
+++ b/background_removal.py
@@ -44,6 +44,7 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
         self.loadingChannelSelect.currentTextChanged.connect(self.on_channel_change)
         self.loadingRemoveButton.clicked.connect(self.on_remove_point)
         self.rparamsTestButton.clicked.connect(self.test_br_params)
+        self.rparamsTable.cellClicked.connect(self.br_cell_click)
 
         self.setWindowTitle("Background Removal")
 
@@ -406,6 +407,23 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
 
         self.main_viewer.refresh_plots()
 
+    def br_cell_click(self, row: int, column: int) -> None:
+        """Callback for item selection in background removal parameters.
+
+        Ensures entire row is selected (mostly for visual appeal)
+
+        Args:
+            row (int):
+                row of cell clicked
+            columns (int):
+                column of cell clicked
+        """
+        self.rparamsTable.setRangeSelected(
+            QtWidgets.QTableWidgetSelectionRange(row, 0, row, 2),
+            True
+        )
+        return
+
 
 # function for amp plugin building
 def build_as_plugin(main_viewer: MainViewer) -> BackgroundRemoval:
@@ -416,6 +434,5 @@ def build_as_plugin(main_viewer: MainViewer) -> BackgroundRemoval:
 
     Args:
         main_viewer: reference to the main window
-
     """
     return BackgroundRemoval(main_viewer)

--- a/background_removal.py
+++ b/background_removal.py
@@ -111,8 +111,8 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
 
         Args:
             event (QtCore.QEvent): qt close event (passed via signal)
-
         """
+
         while len(self.points) > 0:
             self.on_remove_point()
 
@@ -130,6 +130,7 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
             channel_data (numpy.ndarray): image data for given point's given channel
 
         """
+
         return self.points[point_name].get_channel_data(chans=[channel_name])[channel_name]
 
     def on_add_point(self) -> None:
@@ -137,6 +138,7 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
 
         Checks for point existence and adds it to loadingPointsList
         """
+
         point_path = QtWidgets.QFileDialog.getExistingDirectory(self,
                                                                 'Open',
                                                                 '~')
@@ -172,6 +174,7 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
             str:
                 Pretty figure name for background image
         """
+
         reduced_point_name = pathlib.Path(point_name).parts[-2]
         reduced_channel_name = channel_name.split('.')[0]
         return f"{reduced_point_name} channel {reduced_channel_name}"
@@ -192,6 +195,7 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
             str:
                 Pretty figure name for background mask image
         """
+
         reduced_point_name = pathlib.Path(point_name).parts[-2]
         reduced_channel_name = channel_name.split('.')[0]
         return f"{reduced_point_name} channel {reduced_channel_name} mask {br_params}"
@@ -379,7 +383,6 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
 
         Returns:
             background_mask (ndarray): generated binarized mask
-
         """
 
         # generate new array
@@ -408,7 +411,6 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
         Generates background mask with current parameters, plots it,
         adds parameters to parameter table, and stores relevent data
         within the selected 'Point' object.
-
         """
 
         if self.loadingPointsList.currentItem() is None:
@@ -530,6 +532,7 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
             old_row (int): Row of old current cell selected. Unused.
             old_col (int): Column of new current cell selected. Unused.
         """
+
         # adjust for mismatched cell_change call on param deletion
         current_point = self.loadingPointsList.currentItem().text()
         num_br_params = len(self.points[current_point].get_param('BR_params'))
@@ -543,6 +546,7 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
     def remove_br_params(self) -> None:
         """Callback for background reduction parameter row deletion
         """
+
         if self.rparamsTable.currentRow() >= 0:
 
             # get attributes
@@ -558,6 +562,7 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
     def reload_br_params(self) -> None:
         """Callback for editing row of background reduction parameters
         """
+
         if self.rparamsTable.currentRow() >= 0:
 
             # get attributes
@@ -622,4 +627,5 @@ def build_as_plugin(main_viewer: MainViewer) -> BackgroundRemoval:
     Args:
         main_viewer: reference to the main window
     """
+
     return BackgroundRemoval(main_viewer)

--- a/background_removal.py
+++ b/background_removal.py
@@ -102,12 +102,38 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
                 self.loadingPointsList.addItem(point_path)
 
     def _gen_preview_fig_name(self, point_name: str, channel_name: str) -> str:
+        """Generates pretty figure names for preview images
+
+        Args:
+            point_name (str):
+                Path like string to TIFs directory of FOV
+            channel_name (str):
+                Name of channel (with or without .tif(f))
+
+        Returns:
+            str:
+                Pretty figure name for background image
+        """
         reduced_point_name = pathlib.Path(point_name).parts[-2]
         reduced_channel_name = channel_name.split('.')[0]
         return f"{reduced_point_name} channel {reduced_channel_name}"
 
     def _gen_mask_fig_name(self, point_name: str, channel_name: str,
                            br_params: List[numbers.Number]) -> str:
+        """Generates pretty figure names for background mask images
+
+        Args:
+            point_name (str):
+                Path like string to TIFs directory of FOV
+            channel_name (str):
+                Name of channel (with or without .tif(f))
+            br_pararms (list):
+                Parameters used for mask generation
+
+        Returns:
+            str:
+                Pretty figure name for background mask image
+        """
         reduced_point_name = pathlib.Path(point_name).parts[-2]
         reduced_channel_name = channel_name.split('.')[0]
         return f"{reduced_point_name} channel {reduced_channel_name} mask {br_params}"
@@ -144,9 +170,11 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
             )
 
         # gen/update plots
-        newChannel = self.loadingChannelSelect.currentText()
-        channel_data = self._get_point_channel_data(current.text(), newChannel)
-        plot_name = self._gen_preview_fig_name(current.text(), newChannel)
+        new_channel = self.loadingChannelSelect.currentText()
+
+        channel_data = self._get_point_channel_data(current.text(), new_channel)
+
+        plot_name = self._gen_preview_fig_name(current.text(), new_channel)
         if self.preview_id is not None and self.loadingReuseButton.isChecked():
             self.points[previous.text()].remove_figure_id(self.preview_id)
             self.points[current.text()].add_figure_id(self.preview_id)
@@ -188,7 +216,7 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
 
         self.main_viewer.refresh_plots()
 
-    def on_channel_change(self, current_text):
+    def on_channel_change(self, current_text: str) -> None:
         """ Callback for background channel reselection
 
         Refreshes plots w/ new background channel
@@ -235,7 +263,7 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
             # refresh plots
             self.main_viewer.refresh_plots()
 
-    def on_remove_point(self):
+    def on_remove_point(self) -> None:
         """ Callback for Remove Point button
 
         Removes point from list and clears its associated figures
@@ -273,7 +301,8 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
         else:
             print('No points are currently loaded...')
 
-    def _generate_mask(self, background_image, radius, threshold, backcap):
+    def _generate_mask(self, background_image: Any, radius: float, threshold: float,
+                       backcap: int) -> Any:
         """ Mask generation algorithm
 
         Generates binaraized mask used for background removal
@@ -309,7 +338,7 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
 
         return background_mask
 
-    def test_br_params(self):
+    def test_br_params(self) -> None:
         """ Callback for background removal 'test' button
 
         Generates background mask with current parameters, plots it,

--- a/background_removal.py
+++ b/background_removal.py
@@ -2,24 +2,26 @@ from PyQt5 import QtWidgets, QtCore, uic
 
 from mplwidget import ImagePlot
 from point import Point
+from main_viewer import MainViewer
 
 import numpy as np
 from scipy.ndimage import gaussian_filter
 
 import os
 import concurrent.futures
+from typing import Dict
 
 
 class BackgroundRemoval(QtWidgets.QMainWindow):
 
-    def __init__(self, main_viewer):
+    def __init__(self, main_viewer: MainViewer):
         super().__init__()
 
         # set reference to main window
         self.main_viewer = main_viewer
 
         # points dict (indexed by path)
-        self.points = {}
+        self.points: Dict[str, Point] = {}
 
         # reusable figure id's
         self.preview_id = None

--- a/background_removal.py
+++ b/background_removal.py
@@ -37,6 +37,8 @@ class BackgroundRemoval(QtWidgets.QMainWindow):
         self.executer = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
         # connect UI callbacks
+        # TODO: find a good way to automatically determine the types for these
+        #       from .ui files
         self.loadingAddButton.clicked.connect(self.on_add_point)
         self.loadingPointsList.currentItemChanged.connect(self.on_point_change)
         self.loadingChannelSelect.currentTextChanged.connect(self.on_channel_change)

--- a/cohorttreewidget.py
+++ b/cohorttreewidget.py
@@ -69,7 +69,7 @@ class CohortTreeWidget(QtWidgets.QTreeWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-    def loadCohort(self, cohort_head):
+    def load_cohort(self, cohort_head):
         # list lowest depth tifs
         head = CohortTreeWidgetItem(self, cohort_head)
         head.setText(0, os.path.basename(cohort_head))

--- a/cohorttreewidget.py
+++ b/cohorttreewidget.py
@@ -8,15 +8,47 @@ from typing import List
 # Only supports single page tifs as of 6/22/2020
 
 
-def tif_bfs(heads: List[str], max_depth: int = 6) -> None:
-    # Assembles QtTreeWidget structure for cohort w/ bredth-first search
-    # Assumes all tifs of interest are in the same folder depth
-    # Only loads single page tifs
-    # Multi-tiff support will come later
+class CohortTreeWidgetItem(QtWidgets.QTreeWidgetItem):
+    def __init__(self, parent: QtWidgets.QWidget = None, path: str = None) -> None:
+        super().__init__(parent)
+        self.path = path
+
+
+class CohortTreeWidget(QtWidgets.QTreeWidget):
+    def __init__(self, parent: QtWidgets.QWidget = None) -> None:
+        super().__init__(parent)
+
+    def load_cohort(self, cohort_head: str) -> None:
+        # list lowest depth tifs
+        head = CohortTreeWidgetItem(self, cohort_head)
+        head.setText(0, os.path.basename(cohort_head))
+        tif_bfs([head])
+
+
+def tif_bfs(heads: List[CohortTreeWidgetItem], max_depth: int = 6) -> None:
+    """Recursive assembler of QtTreeWidget structure via breadth-first search.
+
+    The child directories and/or tifs of each given head are collected and formated as new
+    CohortTreeWidgetItem's.  If any tifs are found, no more recursive file searches are performed,
+    and the final layers CohortTreeWidgetItem's are made togglable.  However, if no tifs are found,
+    an this function is called recursively with `heads` being the found directories, and a
+    max_depth one lower than the previous `max_depth`.
+
+    Assumes all tifs of interest are within the same folder depth.  Only loads single page tifs.
+    Multi-tiff and MIBITiff support is planned and will come later.
+
+    Args:
+        heads (List[CohortTreeWidgetItem]):
+            Directories to search within. Formated as CohortTreeWidgetItem's so that
+            CohortTreeWidget is automatically built; no need to be built externally.
+        max_depth (int):
+            Maximum file structure search depth. It's best to keep this low, as bfs grow
+            exponentially with depth. Default is 6.
+    """
     if max_depth <= 1:
         return []
-    layer_dirs = []
-    layer_tifs = []
+    layer_dirs: List[CohortTreeWidgetItem] = []
+    layer_tifs: List[CohortTreeWidgetItem] = []
     # build search space for next recursion
     for head in heads:
         # create directory tree items (if no tifs found)
@@ -59,20 +91,3 @@ def tif_bfs(heads: List[str], max_depth: int = 6) -> None:
                 ld.setFlags(ld.flags() & (~QtCore.Qt.ItemIsUserCheckable))
         layer_dirs = [ld for ld in layer_dirs if ld]
         return
-
-
-class CohortTreeWidgetItem(QtWidgets.QTreeWidgetItem):
-    def __init__(self, parent: QtWidgets.QWidget = None, path: str = None) -> None:
-        super().__init__(parent)
-        self.path = path
-
-
-class CohortTreeWidget(QtWidgets.QTreeWidget):
-    def __init__(self, parent: QtWidgets.QWidget = None) -> None:
-        super().__init__(parent)
-
-    def load_cohort(self, cohort_head: str) -> None:
-        # list lowest depth tifs
-        head = CohortTreeWidgetItem(self, cohort_head)
-        head.setText(0, os.path.basename(cohort_head))
-        tif_bfs([head])

--- a/cohorttreewidget.py
+++ b/cohorttreewidget.py
@@ -3,10 +3,12 @@ from PyQt5 import QtWidgets, QtCore
 import os
 import sip
 
+from typing import List
+
 # Only supports single page tifs as of 6/22/2020
 
 
-def tif_bfs(heads, max_depth=6):
+def tif_bfs(heads: List[str], max_depth: int = 6) -> None:
     # Assembles QtTreeWidget structure for cohort w/ bredth-first search
     # Assumes all tifs of interest are in the same folder depth
     # Only loads single page tifs
@@ -60,16 +62,16 @@ def tif_bfs(heads, max_depth=6):
 
 
 class CohortTreeWidgetItem(QtWidgets.QTreeWidgetItem):
-    def __init__(self, parent=None, path=None):
+    def __init__(self, parent: QtWidgets.QWidget = None, path: str = None) -> None:
         super().__init__(parent)
         self.path = path
 
 
 class CohortTreeWidget(QtWidgets.QTreeWidget):
-    def __init__(self, parent=None):
+    def __init__(self, parent: QtWidgets.QWidget = None) -> None:
         super().__init__(parent)
 
-    def load_cohort(self, cohort_head):
+    def load_cohort(self, cohort_head: str) -> None:
         # list lowest depth tifs
         head = CohortTreeWidgetItem(self, cohort_head)
         head.setText(0, os.path.basename(cohort_head))

--- a/figure_manager.py
+++ b/figure_manager.py
@@ -1,6 +1,6 @@
 from collections import deque
 from mplwidget import Plot
-from typing import List
+from typing import List, Union, Dict
 
 # prefilling dictionary prevents slow rehashing
 MAX_FIGS = 64
@@ -8,7 +8,8 @@ MAX_FIGS = 64
 
 class FigureManager(object):
     def __init__(self, plot_list: List[Plot]) -> None:
-        self.figure_map = dict.fromkeys(range((MAX_FIGS * 3) // 2))
+        self.figure_map: Dict[int, Union[Plot, None]] = dict.fromkeys(range((MAX_FIGS * 3) // 2))
+
         self.open_slots = deque([0])
 
         self.plot_list = plot_list
@@ -26,7 +27,7 @@ class FigureManager(object):
         """
         return self.figure_map[index]
 
-    def add_figure(self, plot_object: Plot, name: str = None) -> int:
+    def add_figure(self, plot_object: Plot, name: Union[str, None] = None) -> int:
         """Add new figure to figure manager
 
         Args:
@@ -69,7 +70,7 @@ class FigureManager(object):
 
         return index
 
-    def update_figure(self, index: int, new_plot: Plot, name: str = None) -> None:
+    def update_figure(self, index: int, new_plot: Plot, name: Union[str, None] = None) -> None:
         """Update figure at given index with new plotting data
 
         Args:
@@ -131,7 +132,7 @@ class FigureManager(object):
 
         return True
 
-    def remove_figures(self, indicies: List[int] = None) -> bool:
+    def remove_figures(self, indicies: Union[List[int], None] = None) -> bool:
         """Iteratively remove multiple figures
 
         Args:

--- a/figure_manager.py
+++ b/figure_manager.py
@@ -1,5 +1,6 @@
 from collections import deque
 from mplwidget import Plot
+from plotlistwidget import PlotListWidget
 from typing import List, Union, Dict
 
 # prefilling dictionary prevents slow rehashing
@@ -7,7 +8,7 @@ MAX_FIGS = 64
 
 
 class FigureManager(object):
-    def __init__(self, plot_list: List[Plot]) -> None:
+    def __init__(self, plot_list: PlotListWidget) -> None:
         self.figure_map: Dict[int, Union[Plot, None]] = dict.fromkeys(range((MAX_FIGS * 3) // 2))
 
         self.open_slots = deque([0])
@@ -59,13 +60,13 @@ class FigureManager(object):
         if name is None:
             name = f'Figure {index}'
 
-        self.plot_list.addItem(
+        self.plot_list.add_item(
             name,
             plot_object,
             index
         )
 
-        row = self.plot_list.getItemRowByPath(index)
+        row = self.plot_list.get_item_row_by_path(index)
         self.plot_list.setCurrentRow(row)
 
         return index
@@ -88,10 +89,10 @@ class FigureManager(object):
         del self.figure_map[index]
         self.figure_map[index] = new_plot
 
-        row = self.plot_list.getItemRowByPath(index)
+        row = self.plot_list.get_item_row_by_path(index)
         self.plot_list.item(row).plot = new_plot
         if name is not None:
-            self.plot_list.item(row).text = name
+            self.plot_list.item(row).setText(name)
 
     # TODO: Failing to remove figure or recomputing queue should explicitly throw error or warning
     def remove_figure(self, index: int) -> bool:
@@ -127,8 +128,8 @@ class FigureManager(object):
 
         self._trim_queue()
 
-        row = self.plot_list.getItemRowByPath(index)
-        self.plot_list.deleteItem(row)
+        row = self.plot_list.get_item_row_by_path(index)
+        self.plot_list.delete_item(row)
 
         return True
 

--- a/figure_manager.py
+++ b/figure_manager.py
@@ -1,20 +1,45 @@
 from collections import deque
+from mplwidget import Plot
+from typing import List
 
 # prefilling dictionary prevents slow rehashing
 MAX_FIGS = 64
 
 
 class FigureManager(object):
-    def __init__(self, plot_list):
+    def __init__(self, plot_list: List[Plot]) -> None:
         self.figure_map = dict.fromkeys(range((MAX_FIGS * 3) // 2))
         self.open_slots = deque([0])
 
         self.plot_list = plot_list
 
-    def get_figure(self, index):
+    def get_figure(self, index: int) -> Plot:
+        """Get plotting data for figure at given index
+
+        Args:
+            index (int):
+                Figure index
+
+        Returns:
+            mplwidget.Plot:
+                Plotting data at given index
+        """
         return self.figure_map[index]
 
-    def add_figure(self, plot_object):
+    def add_figure(self, plot_object: Plot, name: str = None) -> int:
+        """Add new figure to figure manager
+
+        Args:
+            plot_object (mplwidget.Plot):
+                New plotting data
+            name (str or None):
+                Name passed to the Main Viewer's plot list.  If None, the plot list will list it
+                as f'Figure {index}'. Default is None.
+
+        Returns:
+            int:
+                Index of new figure
+        """
 
         condition = len(self.open_slots) == 1
 
@@ -30,7 +55,8 @@ class FigureManager(object):
         self.figure_map[index] = plot_object
         self.open_slots[0] += int(condition)
 
-        name = f'Figure {index}'
+        if name is None:
+            name = f'Figure {index}'
 
         self.plot_list.addItem(
             name,
@@ -43,14 +69,41 @@ class FigureManager(object):
 
         return index
 
-    def update_figure(self, index, new_plot):
+    def update_figure(self, index: int, new_plot: Plot, name: str = None) -> None:
+        """Update figure at given index with new plotting data
+
+        Args:
+            index (int):
+                Figure index to update
+            new_plot (mplwidget.Plot):
+                New plotting data
+            name (str or None):
+                Updated name passed to the Main Viewer's plot list.  If None, the plot list name
+                will not be updated.  Default is None.
+
+        Returns:
+            None
+        """
         del self.figure_map[index]
         self.figure_map[index] = new_plot
 
         row = self.plot_list.getItemRowByPath(index)
         self.plot_list.item(row).plot = new_plot
+        if name is not None:
+            self.plot_list.item(row).text = name
 
-    def remove_figure(self, index):
+    # TODO: Failing to remove figure or recomputing queue should explicitly throw error or warning
+    def remove_figure(self, index: int) -> bool:
+        """Remove figure from manager
+
+        Args:
+            index (int):
+                Figure index to remove
+
+        Returns:
+            bool:
+                true on successful removal, otherwise false
+        """
 
         if not self.figure_map[index]:
             print(f'There is no figure to remove at index {index}...')
@@ -78,7 +131,17 @@ class FigureManager(object):
 
         return True
 
-    def remove_figures(self, indicies=None):
+    def remove_figures(self, indicies: List[int] = None) -> bool:
+        """Iteratively remove multiple figures
+
+        Args:
+            indicies (List[int]):
+                indices of figures to remove
+
+        Returns:
+            bool:
+                true on all successful removals, otherwise false
+        """
         return all([self.remove_figure(index) for index in indicies])
 
     def _trim_queue(self):

--- a/main_viewer.py
+++ b/main_viewer.py
@@ -50,13 +50,13 @@ class MainViewer(QtWidgets.QMainWindow):
         event.accept()
 
     def createPluginCallback(self, ui_name):
-        """ Creates plugin callback function
+        """ Creates a callback function for showing/opening the plugin
 
         Args:
             ui_name: Key to access plugin within plugins dictionary
 
         Returns:
-            Creates callback for showing/opening the plugin
+            Callback function to show/open the plugin
 
         """
         def pluginCallback():

--- a/main_viewer.py
+++ b/main_viewer.py
@@ -1,3 +1,8 @@
+# start custom imports
+from cohorttreewidget import CohortTreeWidget
+from plotlistwidget import PlotListWidget
+from mplwidget import MplWidget
+# end custom imports
 from cohorttreewidget import CohortTreeWidgetItem
 from plotlistwidget import PlotListWidgetItem
 import sys
@@ -21,6 +26,20 @@ from typing import Dict, Any
 class MainViewer(QtWidgets.QMainWindow):
 
     def __init__(self):
+        # start typedef
+        self.statusbar: QtWidgets.QStatusBar
+        self.menuPlugins: QtWidgets.QMenu
+        self.menuEdit: QtWidgets.QMenu
+        self.menuFile: QtWidgets.QMenu
+        self.menubar: QtWidgets.QMenuBar
+        self.CohortTreeWidget: CohortTreeWidget
+        self.label_2: QtWidgets.QLabel
+        self.PlotListWidget: PlotListWidget
+        self.label: QtWidgets.QLabel
+        self.MplWidget: MplWidget
+        self.centralwidget: QtWidgets.QWidget
+        # end typedef
+
         super().__init__()
         # load ui elements into MainViewer class
         uic.loadUi("MainViewer.ui", self)

--- a/main_viewer.py
+++ b/main_viewer.py
@@ -1,8 +1,8 @@
-# start custom imports
+# start custom imports - DO NOT MANUALLY EDIT BELOW
 from cohorttreewidget import CohortTreeWidget
 from plotlistwidget import PlotListWidget
 from mplwidget import MplWidget
-# end custom imports
+# end custom imports - DO NOT MANUALLY EDIT ABOVE
 from cohorttreewidget import CohortTreeWidgetItem
 from plotlistwidget import PlotListWidgetItem
 import sys
@@ -26,7 +26,7 @@ from typing import Dict, Any
 class MainViewer(QtWidgets.QMainWindow):
 
     def __init__(self):
-        # start typedef
+        # start typedef - DO NOT MANUALLY EDIT BELOW
         self.statusbar: QtWidgets.QStatusBar
         self.menuPlugins: QtWidgets.QMenu
         self.menuEdit: QtWidgets.QMenu
@@ -38,7 +38,7 @@ class MainViewer(QtWidgets.QMainWindow):
         self.label: QtWidgets.QLabel
         self.MplWidget: MplWidget
         self.centralwidget: QtWidgets.QWidget
-        # end typedef
+        # end typedef - DO NOT MANUALLY EDIT ABOVE
 
         super().__init__()
         # load ui elements into MainViewer class

--- a/main_viewer.py
+++ b/main_viewer.py
@@ -1,3 +1,5 @@
+from cohorttreewidget import CohortTreeWidgetItem
+from plotlistwidget import PlotListWidgetItem
 import sys
 
 from PyQt5 import QtWidgets, QtCore, uic
@@ -13,6 +15,8 @@ import concurrent.futures
 
 import amp
 
+from typing import Dict, Any
+
 
 class MainViewer(QtWidgets.QMainWindow):
 
@@ -22,12 +26,14 @@ class MainViewer(QtWidgets.QMainWindow):
         uic.loadUi("MainViewer.ui", self)
 
         # TODO: load cached plugins
-        self.plugins = {}
+        self.plugins: Dict[str, QtWidgets.QMainWindow] = {}
 
         # General UI threadpool (probably shouldn't use this for big algos)
         self.executer = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
         # connect UI callbacks
+        # TODO: find a good way to automatically determine the types for these
+        #       from .ui files
         self.PlotListWidget.itemChanged.connect(self.on_plot_item_change)
         self.PlotListWidget.currentItemChanged.connect(self.on_plot_list_change)
         self.CohortTreeWidget.itemClicked.connect(self.on_file_toggle)
@@ -40,7 +46,7 @@ class MainViewer(QtWidgets.QMainWindow):
         self.setWindowTitle("Main Viewer")
 
     # reserved by PyQt ( can't follow style guide :/ )
-    def closeEvent(self, event):
+    def closeEvent(self, event: QtCore.QEvent) -> None:
         """ Callback for Main Window Exit/Close
 
         Calls individual close events on open plugins and accepts close event
@@ -50,7 +56,7 @@ class MainViewer(QtWidgets.QMainWindow):
 
         event.accept()
 
-    def create_plugin_callback(self, ui_name):
+    def create_plugin_callback(self, ui_name: str) -> Any:
         """ Creates a callback function for showing/opening the plugin
 
         Args:
@@ -64,7 +70,7 @@ class MainViewer(QtWidgets.QMainWindow):
             self.plugins[ui_name].show()
         return plugin_callback
 
-    def on_plot_item_change(self, item):
+    def on_plot_item_change(self, item: PlotListWidgetItem) -> None:
         """ Change plot list item name callback
 
         Updates PlotListWidget's path to name/ui-text map.
@@ -77,7 +83,8 @@ class MainViewer(QtWidgets.QMainWindow):
         self.PlotListWidget.path_to_name[item.path] = item.text()
 
     # submit update to plot viewer (multithreading makes ui smoother here)
-    def on_plot_list_change(self, current, previous):
+    def on_plot_list_change(self, current: PlotListWidgetItem,
+                            previous: PlotListWidgetItem) -> None:
         """ Callback for updating viewer to display new plots
 
         Uses threadpool for 'pause-less' UI
@@ -94,7 +101,7 @@ class MainViewer(QtWidgets.QMainWindow):
                 current.plot.plot_data
             )
 
-    def refresh_plots(self):
+    def refresh_plots(self) -> None:
         """ Manually update viewer
 
         Use this when PlotListWidget won't directly change, but new plot
@@ -106,7 +113,7 @@ class MainViewer(QtWidgets.QMainWindow):
             self.MplWidget._canvas
         )
 
-    def load_cohort(self):
+    def load_cohort(self) -> None:
         """ Callback for loading files into main viewer
         """
         flags = QtWidgets.QFileDialog.ShowDirsOnly
@@ -116,7 +123,7 @@ class MainViewer(QtWidgets.QMainWindow):
                                                                 flags)
         self.CohortTreeWidget.load_cohort(folderpath)
 
-    def on_file_toggle(self, item, column):
+    def on_file_toggle(self, item: CohortTreeWidgetItem, column: int) -> None:
         """ Callback for toggling image plot of tiff file
 
         Adds/Removes plot of image to main viewer + plot list
@@ -150,7 +157,7 @@ class MainViewer(QtWidgets.QMainWindow):
         ):
             self.PlotListWidget.delete_item(row)
 
-    def add_plugin(self):
+    def add_plugin(self) -> None:
         """ Call back for loading plugin
 
         In the future, new (i.e uncached) plugins will be cached for

--- a/main_viewer.py
+++ b/main_viewer.py
@@ -176,7 +176,8 @@ class MainViewer(QtWidgets.QMainWindow):
 
 
 # start application
-app = QtWidgets.QApplication(sys.argv)
-window = MainViewer()
-window.show()
-sys.exit(app.exec_())
+if __name__ == "__main__":
+    app = QtWidgets.QApplication(sys.argv)
+    window = MainViewer()
+    window.show()
+    sys.exit(app.exec_())

--- a/main_viewer.py
+++ b/main_viewer.py
@@ -28,17 +28,18 @@ class MainViewer(QtWidgets.QMainWindow):
         self.executer = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
         # connect UI callbacks
-        self.PlotListWidget.itemChanged.connect(self.onPlotItemChange)
-        self.PlotListWidget.currentItemChanged.connect(self.onPlotListChange)
-        self.CohortTreeWidget.itemClicked.connect(self.onFileToggle)
-        self.actionOpen_Cohort.triggered.connect(self.loadCohort)
-        self.actionAdd_Plugins.triggered.connect(self.addPlugin)
+        self.PlotListWidget.itemChanged.connect(self.on_plot_item_change)
+        self.PlotListWidget.currentItemChanged.connect(self.on_plot_list_change)
+        self.CohortTreeWidget.itemClicked.connect(self.on_file_toggle)
+        self.actionOpen_Cohort.triggered.connect(self.load_cohort)
+        self.actionAdd_Plugins.triggered.connect(self.add_plugin)
 
         # configure figure manager
         self.figures = FigureManager(self.PlotListWidget)
 
         self.setWindowTitle("Main Viewer")
 
+    # reserved by PyQt ( can't follow style guide :/ )
     def closeEvent(self, event):
         """ Callback for Main Window Exit/Close
 
@@ -49,7 +50,7 @@ class MainViewer(QtWidgets.QMainWindow):
 
         event.accept()
 
-    def createPluginCallback(self, ui_name):
+    def create_plugin_callback(self, ui_name):
         """ Creates a callback function for showing/opening the plugin
 
         Args:
@@ -59,11 +60,11 @@ class MainViewer(QtWidgets.QMainWindow):
             Callback function to show/open the plugin
 
         """
-        def pluginCallback():
+        def plugin_callback():
             self.plugins[ui_name].show()
-        return pluginCallback
+        return plugin_callback
 
-    def onPlotItemChange(self, item):
+    def on_plot_item_change(self, item):
         """ Change plot list item name callback
 
         Updates PlotListWidget's path to name/ui-text map.
@@ -76,7 +77,7 @@ class MainViewer(QtWidgets.QMainWindow):
         self.PlotListWidget.path_to_name[item.path] = item.text()
 
     # submit update to plot viewer (multithreading makes ui smoother here)
-    def onPlotListChange(self, current, previous):
+    def on_plot_list_change(self, current, previous):
         """ Callback for updating viewer to display new plots
 
         Uses threadpool for 'pause-less' UI
@@ -93,7 +94,7 @@ class MainViewer(QtWidgets.QMainWindow):
                 current.plot.plot_data
             )
 
-    def refreshPlots(self):
+    def refresh_plots(self):
         """ Manually update viewer
 
         Use this when PlotListWidget won't directly change, but new plot
@@ -101,11 +102,11 @@ class MainViewer(QtWidgets.QMainWindow):
 
         """
         self.executer.submit(
-            self.PlotListWidget.refreshCurrentPlot,
+            self.PlotListWidget.refresh_current_plot,
             self.MplWidget._canvas
         )
 
-    def loadCohort(self):
+    def load_cohort(self):
         """ Callback for loading files into main viewer
         """
         flags = QtWidgets.QFileDialog.ShowDirsOnly
@@ -113,9 +114,9 @@ class MainViewer(QtWidgets.QMainWindow):
                                                                 'Open Cohort',
                                                                 '~',
                                                                 flags)
-        self.CohortTreeWidget.loadCohort(folderpath)
+        self.CohortTreeWidget.load_cohort(folderpath)
 
-    def onFileToggle(self, item, column):
+    def on_file_toggle(self, item, column):
         """ Callback for toggling image plot of tiff file
 
         Adds/Removes plot of image to main viewer + plot list
@@ -138,18 +139,18 @@ class MainViewer(QtWidgets.QMainWindow):
         # add image if not already in plot list
         if (
             item.checkState(0)
-            and self.PlotListWidget.getItemRowByPath(item.path) < 0
+            and self.PlotListWidget.get_item_row_by_path(item.path) < 0
         ):
-            self.PlotListWidget.addItem(
+            self.PlotListWidget.add_item(
                 name, ImagePlot(asarray(Image.open(item.path))), item.path)
         # remove image otherwise
         elif (
-            (row := self.PlotListWidget.getItemRowByPath(item.path)) >= 0
+            (row := self.PlotListWidget.get_item_row_by_path(item.path)) >= 0
             and not item.checkState(0)
         ):
-            self.PlotListWidget.deleteItem(row)
+            self.PlotListWidget.delete_item(row)
 
-    def addPlugin(self):
+    def add_plugin(self):
         """ Call back for loading plugin
 
         In the future, new (i.e uncached) plugins will be cached for
@@ -171,7 +172,7 @@ class MainViewer(QtWidgets.QMainWindow):
             # bind plugin+creation callback to menu action
             self.menuPlugins.addAction(
                 ui_name,
-                self.createPluginCallback(ui_name))
+                self.create_plugin_callback(ui_name))
 
 
 # start application

--- a/main_viewer.py
+++ b/main_viewer.py
@@ -51,8 +51,6 @@ class MainViewer(QtWidgets.QMainWindow):
         self.executer = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
         # connect UI callbacks
-        # TODO: find a good way to automatically determine the types for these
-        #       from .ui files
         self.PlotListWidget.itemChanged.connect(self.on_plot_item_change)
         self.PlotListWidget.currentItemChanged.connect(self.on_plot_list_change)
         self.CohortTreeWidget.itemClicked.connect(self.on_file_toggle)

--- a/mplwidget.py
+++ b/mplwidget.py
@@ -11,16 +11,19 @@ import matplotlib.cm as cm
 
 from matplotlib.image import AxesImage
 
+from typing import Callable, Dict, Any, List
+
 
 class Plot(object):
     # base class for plot objects
     # plot objects store a plot_update function, and associated plot_data
-    def __init__(self, plot_update, plot_data):
+    def __init__(self, plot_update: Callable[[FigureCanvas, Dict[str, Any]], None],
+                 plot_data: Dict[str, Any]) -> None:
         self.plot_update = plot_update
         self.plot_data = plot_data
 
 
-def image_plot_update(canvas, data):
+def image_plot_update(canvas: FigureCanvas, data: Dict[str, Any]) -> None:
     # ImagePlot update function
     cur_xlim = []
     cur_ylim = []
@@ -37,14 +40,14 @@ def image_plot_update(canvas, data):
 
 class ImagePlot(Plot):
     # plots images via imshow
-    def __init__(self, data):
+    def __init__(self, data: Any) -> None:
         super().__init__(image_plot_update, {'image': data})
 
 
 # a more customizable toolbar (loadable icons)
 class CleanToolbar(NavigationToolbar):
-    toolitems = [t for t in NavigationToolbar.toolitems if
-                 t[0] in ('Home', 'Pan', 'Zoom', 'Save')]
+    toolitems: List[str] = [t for t in NavigationToolbar.toolitems if
+                            t[0] in ('Home', 'Pan', 'Zoom', 'Save')]
 
     # custom icon injection (could be made to be not so hardcoded)
     '''
@@ -56,12 +59,12 @@ class CleanToolbar(NavigationToolbar):
     # hardcoding is a little bad here?
     resourcedir = "./resources/icons/"
 
-    def __init__(self, canvas=None, parent=None):
+    def __init__(self, canvas: FigureCanvas = None, parent: QtWidgets.QWidget = None) -> None:
         super().__init__(canvas, parent)
         self.sizePolicy().setHorizontalPolicy(QtWidgets.QSizePolicy.Expanding)
 
     # overloads _icon function to support custom icons
-    def _icon(self, name):
+    def _icon(self, name: str) -> QtGui.QIcon:
         if path.exists(path.join(self.basedir, name)):
             return super()._icon(name)
         else:
@@ -73,7 +76,7 @@ class CleanToolbar(NavigationToolbar):
 
 # class for handling plotting widget
 class MplWidget(QtWidgets.QWidget):
-    def __init__(self, parent=None):
+    def __init__(self, parent: QtWidgets.QWidget = None):
         super().__init__(parent)
         self.sizePolicy().setHorizontalPolicy(QtWidgets.QSizePolicy.Expanding)
         self._canvas = FigureCanvas(Figure(figsize=(5, 3)))

--- a/parse_ui.py
+++ b/parse_ui.py
@@ -36,7 +36,7 @@ for ui_file, py_file in pairs:
             del py_data[0]
         del py_data[0]
 
-    py_data.insert(0, '# end custom imports\n')
+    py_data.insert(0, '# end custom imports - DO NOT MANUALLY EDIT ABOVE\n')
     for cc in custom_classes:
         for h_file in py_files:
             all_classes = [
@@ -52,7 +52,7 @@ for ui_file, py_file in pairs:
                         f'from {all_classes[cc == all_names].__module__} import {cc}\n'
                     )
                     break
-    py_data.insert(0, '# start custom imports\n')
+    py_data.insert(0, '# start custom imports - DO NOT MANUALLY EDIT BELOW\n')
 
     # create stub type for all widgets
     init_line_idx = [idx for idx, line in enumerate(py_data) if '__init__' in line][0]
@@ -61,7 +61,7 @@ for ui_file, py_file in pairs:
             del py_data[init_line_idx + 1]
         del py_data[init_line_idx + 1]
 
-    py_data.insert(init_line_idx + 1, '        # end typedef\n')
+    py_data.insert(init_line_idx + 1, '        # end typedef - DO NOT MANUALLY EDIT ABOVE\n')
     for elem in root.findall('.//widget'):
         # handle non customs
         if elem.get('class') not in custom_classes + ['QMainWindow']:
@@ -74,6 +74,6 @@ for ui_file, py_file in pairs:
                 init_line_idx + 1,
                 f"        self.{elem.get('name')}: {elem.get('class')}\n"
             )
-    py_data.insert(init_line_idx + 1, '        # start typedef\n')
+    py_data.insert(init_line_idx + 1, '        # start typedef - DO NOT MANUALLY EDIT BELOW\n')
     with open(py_file, 'w') as f:
         f.writelines(py_data)

--- a/parse_ui.py
+++ b/parse_ui.py
@@ -7,6 +7,9 @@ import importlib
 
 # utility script for parsing .ui files for type information
 
+# !! Be extra careful when making changes here! This directly writes into background_removal.py
+# !! and main_viewer.py
+
 # collect ui files
 ui_files = [file for file in os.listdir() if file.endswith('.ui')]
 

--- a/parse_ui.py
+++ b/parse_ui.py
@@ -1,0 +1,79 @@
+import os
+import re
+import xml.etree.ElementTree as ET
+
+import inspect
+import importlib
+
+# utility script for parsing .ui files for type information
+
+# collect ui files
+ui_files = [file for file in os.listdir() if file.endswith('.ui')]
+
+# collect .py files
+py_files = [file for file in os.listdir() if file.endswith('.py')]
+
+# pair ui with py files (ui CamelCase to py snake_case)
+pairs = []
+for ui_file in ui_files:
+    for py_file in py_files:
+        if py_file.split('.')[0] == re.sub(r'(?<!^)(?=[A-Z])', '_', ui_file.split('.')[0]).lower():
+            pairs.append((ui_file, py_file))
+            break
+
+# parse ui file and create stub file
+for ui_file, py_file in pairs:
+    with open(py_file, 'r') as f:
+        py_data = f.readlines()
+
+    tree = ET.parse(ui_file)
+    root = tree.getroot()
+
+    # collect custom classes and handle imports
+    custom_classes = [cust[0].text for cust in root.findall('.//customwidget')]
+    if 'start custom imports' in py_data[0]:
+        while 'end custom imports' not in py_data[0]:
+            del py_data[0]
+        del py_data[0]
+
+    py_data.insert(0, '# end custom imports\n')
+    for cc in custom_classes:
+        for h_file in py_files:
+            all_classes = [
+                obj
+                for obj in inspect.getmembers(importlib.import_module(h_file.split('.')[0]))
+                if inspect.isclass(obj[1]) and obj[1].__module__ == h_file.split('.')[0]
+            ]
+            if all_classes:
+                all_names, all_classes = zip(*all_classes)
+                if cc in all_names:
+                    py_data.insert(
+                        0,
+                        f'from {all_classes[cc == all_names].__module__} import {cc}\n'
+                    )
+                    break
+    py_data.insert(0, '# start custom imports\n')
+
+    # create stub type for all widgets
+    init_line_idx = [idx for idx, line in enumerate(py_data) if '__init__' in line][0]
+    if 'start typedef' in py_data[init_line_idx + 1]:
+        while 'end typedef' not in py_data[init_line_idx + 1]:
+            del py_data[init_line_idx + 1]
+        del py_data[init_line_idx + 1]
+
+    py_data.insert(init_line_idx + 1, '        # end typedef\n')
+    for elem in root.findall('.//widget'):
+        # handle non customs
+        if elem.get('class') not in custom_classes + ['QMainWindow']:
+            py_data.insert(
+                init_line_idx + 1,
+                f"        self.{elem.get('name')}: QtWidgets.{elem.get('class')}\n"
+            )
+        elif elem.get('class') in custom_classes:
+            py_data.insert(
+                init_line_idx + 1,
+                f"        self.{elem.get('name')}: {elem.get('class')}\n"
+            )
+    py_data.insert(init_line_idx + 1, '        # start typedef\n')
+    with open(py_file, 'w') as f:
+        f.writelines(py_data)

--- a/plotlistwidget.py
+++ b/plotlistwidget.py
@@ -21,14 +21,14 @@ class PlotListWidget(QtWidgets.QListWidget):
         super().__init__(parent)
         self.path_to_name = {}
 
-    def addItem(self, name, plot, path):
+    def add_item(self, name, plot, path):
         super().addItem(PlotListWidgetItem(name, plot, path))
         self.path_to_name[path] = name
 
     # path is a static breadcumb trail to allow for renaming.
     # for file-images this is literally the filepath.
     # for other plots, this will be a different unique id.
-    def getItemRowByPath(self, path):
+    def get_item_row_by_path(self, path):
         if path in self.path_to_name.keys():
             name = self.path_to_name[path]
         else:
@@ -37,9 +37,9 @@ class PlotListWidget(QtWidgets.QListWidget):
         return self.row(matches[0]) if matches else -1
 
     # clear entry in path to name dictionary and delete
-    def deleteItem(self, row):
+    def delete_item(self, row):
         self.path_to_name.pop(self.item(row).path, None)
         sip.delete(self.takeItem(row))
 
-    def refreshCurrentPlot(self, canvas):
+    def refresh_current_plot(self, canvas):
         self.currentItem().refresh(canvas)

--- a/plotlistwidget.py
+++ b/plotlistwidget.py
@@ -1,34 +1,39 @@
 from PyQt5 import QtWidgets, QtCore
 
+from matplotlib.backends.backend_qt5agg import FigureCanvas
+from mplwidget import Plot
+
 import sip
+
+from typing import Dict
 
 # Handles storing plotting data in Qt List
 
 
 class PlotListWidgetItem(QtWidgets.QListWidgetItem):
-    def __init__(self, text=None, plot=None, path=None):
+    def __init__(self, text: str = None, plot: Plot = None, path: str = None) -> None:
         super().__init__(text)
         self.setFlags(self.flags() | QtCore.Qt.ItemIsEditable)
         self.plot = plot
         self.path = path
 
-    def refresh(self, canvas):
+    def refresh(self, canvas: FigureCanvas):
         self.plot.plot_update(canvas, self.plot.plot_data)
 
 
 class PlotListWidget(QtWidgets.QListWidget):
-    def __init__(self, parent=None):
+    def __init__(self, parent: QtWidgets.QWidget = None):
         super().__init__(parent)
-        self.path_to_name = {}
+        self.path_to_name: Dict[str, str] = {}
 
-    def add_item(self, name, plot, path):
+    def add_item(self, name: str, plot: Plot, path: str) -> None:
         super().addItem(PlotListWidgetItem(name, plot, path))
         self.path_to_name[path] = name
 
     # path is a static breadcumb trail to allow for renaming.
     # for file-images this is literally the filepath.
     # for other plots, this will be a different unique id.
-    def get_item_row_by_path(self, path):
+    def get_item_row_by_path(self, path: str) -> int:
         if path in self.path_to_name.keys():
             name = self.path_to_name[path]
         else:
@@ -37,9 +42,9 @@ class PlotListWidget(QtWidgets.QListWidget):
         return self.row(matches[0]) if matches else -1
 
     # clear entry in path to name dictionary and delete
-    def delete_item(self, row):
+    def delete_item(self, row: int) -> None:
         self.path_to_name.pop(self.item(row).path, None)
         sip.delete(self.takeItem(row))
 
-    def refresh_current_plot(self, canvas):
+    def refresh_current_plot(self, canvas: FigureCanvas) -> None:
         self.currentItem().refresh(canvas)

--- a/point.py
+++ b/point.py
@@ -35,21 +35,21 @@ class Point:
 
     def add_figure_id(self, id: int) -> None:
         self.figure_ids.append(id)
-        # print(f'{self.path}\nAfter add {self.figure_ids}\n')
 
     def remove_figure_id(self, id: int) -> None:
         self.figure_ids.remove(id)
-        # print(f'{self.path}\nAfter remove {self.figure_ids}\n')
 
     def safe_remove_figure_id(self, id: int) -> None:
         try:
             self.figure_ids.remove(id)
-            # print(f'{self.path}\nAfter SAFE remove {self.figure_ids}\n')
         except ValueError:
             return
 
     def get_channel_names(self) -> List[str]:
         return [chan.split('.')[0] for chan in self.channels]
+
+    def get_point_dir(self) -> str:
+        return pathlib.Path(self.tif_path).parents[0]
 
     def get_parent_dir(self) -> str:
         return pathlib.Path(self.tif_path).parents[1]

--- a/point.py
+++ b/point.py
@@ -3,13 +3,15 @@ import os
 from PIL import Image
 import numpy as np
 
+from typing import List
+
 
 class Point(object):
-    def __init__(self, path, channels):
+    def __init__(self, path: str, channels: List[str]) -> None:
         self.path = path
         self.channels = channels
 
-        self.figure_ids = []
+        self.figure_ids: List[int] = []
         self.params = {}
 
     def add_figure_id(self, id):

--- a/point.py
+++ b/point.py
@@ -4,6 +4,7 @@ from PIL import Image
 import numpy as np
 
 from typing import List, Union, Dict, Any
+from numbers import Number
 
 
 class Point(object):
@@ -12,7 +13,7 @@ class Point(object):
         self.channels = channels
 
         self.figure_ids: List[int] = []
-        self.params = {}
+        self.params: Dict[str, dict] = {}
 
     def add_figure_id(self, id: int) -> None:
         self.figure_ids.append(id)
@@ -26,10 +27,10 @@ class Point(object):
         except ValueError:
             return
 
-    def set_param(self, name: str, data: dict) -> None:
+    def set_param(self, name: str, data: List[List[Number]]) -> None:
         self.params[name] = data
 
-    def get_param(self, name: str) -> Union[dict, None]:
+    def get_param(self, name: str) -> Union[List[List[Number]], None]:
         if name in self.params:
             return self.params[name]
         else:

--- a/point.py
+++ b/point.py
@@ -7,13 +7,29 @@ from typing import List, Union, Dict, Any
 from numbers import Number
 
 
-class Point(object):
+class Point:
+    """Class containing relevent information and methods for a managing points within AMP plugins
+
+    Raw point data is not handled by this class; rather this class manages file locations and
+    dynamically loads channel data when requested.
+
+    Atributes:
+        path (str):
+            path to folder of tifs for point
+        channels (List[str]):
+            file names for channels
+        figure_ids (List[int]):
+            figure id's for point related figures within figure_manager
+        params (Dict[str, Any]):
+            dictionary containing arbitrary algorithm inputs
+    """
+
     def __init__(self, path: str, channels: List[str]) -> None:
         self.path = path
         self.channels = channels
 
         self.figure_ids: List[int] = []
-        self.params: Dict[str, dict] = {}
+        self.params: Dict[str, Any] = {}
 
     def add_figure_id(self, id: int) -> None:
         self.figure_ids.append(id)

--- a/point.py
+++ b/point.py
@@ -3,7 +3,7 @@ import os
 from PIL import Image
 import numpy as np
 
-from typing import List
+from typing import List, Union, Dict, Any
 
 
 class Point(object):
@@ -14,38 +14,39 @@ class Point(object):
         self.figure_ids: List[int] = []
         self.params = {}
 
-    def add_figure_id(self, id):
+    def add_figure_id(self, id: int) -> None:
         self.figure_ids.append(id)
 
-    def remove_figure_id(self, id):
+    def remove_figure_id(self, id: int) -> None:
         self.figure_ids.remove(id)
 
-    def safe_remove_figure_id(self, id):
+    def safe_remove_figure_id(self, id: int) -> None:
         try:
             self.figure_ids.remove(id)
         except ValueError:
             return
 
-    def set_param(self, name, data):
+    def set_param(self, name: str, data: dict) -> None:
         self.params[name] = data
 
-    def get_param(self, name):
+    def get_param(self, name: str) -> Union[dict, None]:
         if name in self.params:
             return self.params[name]
         else:
             return None
 
-    def remove_param(self, name):
+    def remove_param(self, name: str) -> None:
         del self.params[name]
 
-    def get_channel_data(self, chans=None):
+    def get_channel_data(self,
+                         chans: Union[List[str], None] = None) -> Union[Dict[str, Any], None]:
         if chans is None:
             chans = self.channels
         elif not all(chan in self.channels for chan in chans):
             print(f'Some channels in, {chans}, could not be located')
             return
 
-        data_out = {}
+        data_out: Dict[str, Any] = {}
         for chan in chans:
             full_path = os.path.join(self.path, chan)
             data_out[chan] = np.asarray(Image.open(full_path))

--- a/point.py
+++ b/point.py
@@ -18,6 +18,12 @@ class Point(object):
     def remove_figure_id(self, id):
         self.figure_ids.remove(id)
 
+    def safe_remove_figure_id(self, id):
+        try:
+            self.figure_ids.remove(id)
+        except ValueError:
+            return
+
     def set_param(self, name, data):
         self.params[name] = data
 

--- a/point.py
+++ b/point.py
@@ -2,6 +2,7 @@ import os
 
 from PIL import Image
 import numpy as np
+import pathlib
 
 from typing import List, Union, Dict, Any
 from numbers import Number
@@ -49,6 +50,12 @@ class Point:
 
     def get_channel_names(self) -> List[str]:
         return [chan.split('.')[0] for chan in self.channels]
+
+    def get_parent_dir(self) -> str:
+        return pathlib.Path(self.tif_path).parents[1]
+
+    def get_top_dir(self) -> str:
+        return pathlib.Path(self.tif_path).parents[2]
 
     def set_param(self, name: str, data: List[List[Number]]) -> None:
         self.params[name] = data

--- a/point.py
+++ b/point.py
@@ -33,13 +33,16 @@ class Point:
 
     def add_figure_id(self, id: int) -> None:
         self.figure_ids.append(id)
+        # print(f'{self.path}\nAfter add {self.figure_ids}\n')
 
     def remove_figure_id(self, id: int) -> None:
         self.figure_ids.remove(id)
+        # print(f'{self.path}\nAfter remove {self.figure_ids}\n')
 
     def safe_remove_figure_id(self, id: int) -> None:
         try:
             self.figure_ids.remove(id)
+            # print(f'{self.path}\nAfter SAFE remove {self.figure_ids}\n')
         except ValueError:
             return
 


### PR DESCRIPTION
Seeks to address all steps referenced in issue #1. Closes issue #1 .

## **Completed steps**
 - togglable figure reuse button
 - Better figure names in background removal
 - UI for mask generation parameters functional
 - UI for evaluation parameters functional
 - evaluation parameter data/figures handled similarly to generation parameter data/figures
 - Load Params and Remove Background buttons operational

## **Additional features added**
 - ui file parser script for qt-widget type annotations
 - prettier point and channel naming
 - multiple point loading/adding

## **Other notes**
### Need Figure Deletion
Because there is no figure reuse for evaluation, figures often 'pile up' with no way to delete them except delete the points.  This isn't a problem in MAUI because figures can be directly deleted.  This need for a general way of deleting figures will be appended to issue #2.  

One solution is to have PlotListWidgetItem could hold a function handle to generically handle figure deletions on the plugin side and add 'remove buttons' to the main viewer which calls that function handle.

### Point Loading
Currently, only single-file tifs are supported, as with main viewer.  Creating a general/common tif loading solution (maybe borrowing from `ark-analysis`?) would add mibitiff support.  This is useful for other plugins as well, so it'll likely be addressed in a separate PR relating to issue #3 .